### PR TITLE
Fix write error output

### DIFF
--- a/BuildDocs.ps1
+++ b/BuildDocs.ps1
@@ -121,7 +121,7 @@ function Build-EnglishDoc {
     Write-Host -ForegroundColor Yellow "Start building English documentation."
 
     # Output to both build.log and console
-    docfx build en\docfx.json
+    docfx build en\docfx.json | Write-Host
 
 
     return $LastExitCode
@@ -362,7 +362,7 @@ if ($isEnLanguage -or $isAllLanguages)
    $exitCode = Build-EnglishDoc
    if ($exitCode -ne 0)
    {
-       Write-Error -ForegroundColor Red "Failed to build English documentation. ExitCode: $exitCode"
+       Write-Error "Failed to build English documentation. ExitCode: $exitCode"
        Stop-Transcript
        Read-Host -Prompt "Press any ENTER to exit..."
        return $exitCode

--- a/BuildDocs.ps1
+++ b/BuildDocs.ps1
@@ -102,7 +102,7 @@ function Generate-APIDoc {
     Write-Host -ForegroundColor Green "Generating API documentation..."
 
     # Build metadata from C# source, docfx runs dotnet restore
-    docfx metadata en/docfx.json
+    docfx metadata en/docfx.json | Write-Host
     return $LastExitCode
 }
 
@@ -341,7 +341,7 @@ if ($API)
     $exitCode = Generate-APIDoc
     if($exitCode -ne 0)
     {
-        Write-Error -ForegroundColor Red "Failed to generate API metadata. ExitCode: $exitCode"
+        Write-Error "Failed to generate API metadata. ExitCode: $exitCode"
         Stop-Transcript
         Read-Host -Prompt "Press any ENTER to exit..."
         return $exitCode

--- a/BuildDocs.ps1
+++ b/BuildDocs.ps1
@@ -142,7 +142,7 @@ function Build-NonEnglishDoc {
             Remove-Item $langFolder/* -recurse -Verbose
         }
         else{
-            New-Item -Path $langFolder -ItemType Directory -Verbose
+            $discard = New-Item -Path $langFolder -ItemType Directory -Verbose
         }
 
         # Copy all files from en folder to the selected language folder, this way we can keep en files that are not translated
@@ -201,7 +201,7 @@ function Build-NonEnglishDoc {
         (Get-Content $langFolder/docfx.json) -replace "$SiteDir/en","$SiteDir/$($SelectedLanguage.Language)" | Set-Content -Encoding UTF8 $langFolder/docfx.json
 
 
-        docfx build $langFolder\docfx.json
+        docfx build $langFolder\docfx.json | Write-Host
 
         Remove-Item $langFolder -Recurse -Verbose
 
@@ -224,7 +224,7 @@ function Build-AllLanguagesDocs {
 
             if ($exitCode -ne 0)
             {
-                Write-Error -ForegroundColor Red "Failed to build $($SelectedLanguage.Name) documentation. ExitCode: $exitCode"
+                Write-Error "Failed to build $($SelectedLanguage.Name) documentation. ExitCode: $exitCode"
                 Stop-Transcript
                 return $exitCode
             }


### PR DESCRIPTION
Fixes the Previous Write-Error misbehaviour
Problem was that the Function wrote with docfx to Write-OutPut pipeline and not to Write-Host so the return wasnt actually the $LastExitcode , it was the entire output which always fails.

Also removed -ForeGroundColor from write-error

Needs Testing for edge cases, and let it intentionally fail. On Success it behaves correctly.